### PR TITLE
feat(imgr): enable arbitrary user toggle between defined versions

### DIFF
--- a/imgr.py
+++ b/imgr.py
@@ -181,7 +181,13 @@ def add(hutch, ioc, version, hostport, disable):
     sys.exit(0)
 
 def upgrade(hutch, ioc, version):
-    if not utils.check_auth(pwd.getpwuid(os.getuid())[0], hutch):
+    # check if the version change is permissible 
+    allow_toggle = utils.check_special(hutch, ioc, version)
+
+    # check if user is authed to do any upgrade
+    allow_upgrade = utils.check_auth(pwd.getpwuid(os.getuid())[0], hutch)
+
+    if not (allow_upgrade or allow_toggle):
         print "Not authorized!"
         sys.exit(1)
     if not utils.validateDir(version, ioc):


### PR DESCRIPTION
## Feature add:
- Backwards compatible upgrade to the `iocmanager.special` permissioning file. 
- Line entries can now be:
  - old: `[ioc-name]`
  - new: `[ioc-name]:permissioned_version1,permissioned_version2` 

We have expanded the function `check_special` to have an optional argument of `version` which is utilized in the `upgrade` function call:

https://github.com/pcdshub/IocManager/blob/f3d69bf6dc16db44a3f60845584c9643fa55a7b7/imgr.py#L183-L192

https://github.com/pcdshub/IocManager/blob/808f19b863f0ab21ae42b735d8b7b66aeaf21b4e/utils.py#L891-L908

If the user is both not permissioned to upgrade and not permissioned to toggle the upgrade request is aborted. 

## Description
Ticket [ECS-3765](https://jira.slac.stanford.edu/browse/ECS-3765) requests a script to switch timing of the HXR-GEMs for the NC and SC timing schemas. 

For the SC timing schema the crate that contains the HXR-GEM cannot be upgraded (or is prohibitively expensive to upgrade) which means the non SLAC EVR cannot receive / decode LCLS2 timing pulses. 

To circumvent this Silke hardwired the LCLS2 timing signal from the IM2K0 to the HXR-GEM enabling LCLS2 timing to be passed to the L, hard x-ray, side of things. This means that as long as the hack exists and we want to collect SC (LCLSII) data on the HXR-GEM we need to toggle the IOC software to be the one that ignores timing and triggers when the IM2K0 camera triggers and we need a mechanism to toggle it back when we want to send NC beam to the HXR-GEM and get the additional information (timestamps) provided by actually going through the EVR on the crate.

This toggle can be accomplished [manually](https://confluence.slac.stanford.edu/pages/viewpage.action?spaceKey=PCDS&title=LCLS+II+Timing+Switchover+for+GEMs):
- From machine in the CA network: `caput KFE:CAM:TPR:02:MODE X` where X == `NC` or `SC`
  - I have heard but not confirmed this sets a bunch of PVs to predetermined values
- Switch the running software via `imgr`
  - `ioc/fee/GasDetDAQ/R4.0.22` <- for NC
  - `ioc/fee/GasDetDAQ/R4.0.22-NOTS` <- SC

To automate the above we had a few options:

1. Add the ioc control account to the `iocmanager.auth` file which would allow the arbitrary upgrades to be done by operators
2. Have some event based executable listening for the operator request and running the `imgr` command via a permissioned user
3. **Extend the `iocmanager.special` file to enable operators to toggle between known versions**

This implementation implements option 3. 
