### PR TITLE
FIX: hotfix for rhel7, rhel5 launchers

### DIFF
--- a/applyConfig
+++ b/applyConfig
@@ -14,4 +14,7 @@ source $PSPKG_ROOT/etc/set_env.sh
 if [ X$SCRIPTROOT == X ]; then
     export SCRIPTROOT=$PYPS_ROOT/config/$2/iocmanager
 fi
+if [ ! -f "$SCRIPTROOT"/applyConfig.py ]; then
+    export SCRIPTROOT="$(dirname "$(realpath "${0}")")"
+fi
 python $SCRIPTROOT/applyConfig.py "$@"

--- a/fixTelnet
+++ b/fixTelnet
@@ -21,4 +21,7 @@ source $PSPKG_ROOT/etc/set_env.sh
 if [ X$SCRIPTROOT == X ]; then
     export SCRIPTROOT=$PYPS_ROOT/config/$cfg/iocmanager
 fi
+if [ ! -f "$SCRIPTROOT"/fixTelnet.py ]; then
+    export SCRIPTROOT="$(dirname "$(realpath "${0}")")"
+fi
 python $SCRIPTROOT/fixTelnet.py "$@"

--- a/getDirectory
+++ b/getDirectory
@@ -16,4 +16,7 @@ source $PSPKG_ROOT/etc/set_env.sh
 if [ X$SCRIPTROOT == X ]; then
     export SCRIPTROOT=$PYPS_ROOT/config/$2/iocmanager
 fi
+if [ ! -f "$SCRIPTROOT"/getDirectory.py ]; then
+    export SCRIPTROOT="$(dirname "$(realpath "${0}")")"
+fi
 python $SCRIPTROOT/getDirectory.py "$@"

--- a/initIOC
+++ b/initIOC
@@ -18,6 +18,9 @@ fi
 echo Using configuration $cfg.
 
 export SCRIPTROOT=$PYPS_ROOT/config/$cfg/iocmanager
+if [ ! -f "$SCRIPTROOT"/initIOC.hutch ]; then
+    export SCRIPTROOT="$(dirname "$(realpath "${0}")")"
+fi
 
 # Setup our path, so we can find procServ/procmgrd!
 export PSPKG_RELEASE=controls-basic-0.0.1

--- a/installConfig
+++ b/installConfig
@@ -15,4 +15,7 @@ source $PSPKG_ROOT/etc/set_env.sh
 if [ X$SCRIPTROOT == X ]; then
     export SCRIPTROOT=$PYPS_ROOT/config/$1/iocmanager
 fi
+if [ ! -f "$SCRIPTROOT"/installConfig.py ]; then
+    export SCRIPTROOT="$(dirname "$(realpath "${0}")")"
+fi
 python $SCRIPTROOT/installConfig.py "$@"

--- a/startAll
+++ b/startAll
@@ -16,4 +16,7 @@ source $PSPKG_ROOT/etc/set_env.sh
 if [ X$SCRIPTROOT == X ]; then
     export SCRIPTROOT=/reg/g/pcds/pyps/config/$1/iocmanager
 fi
+if [ ! -f "$SCRIPTROOT"/startAll.py ]; then
+    export SCRIPTROOT="$(dirname "$(realpath "${0}")")"
+fi
 python $SCRIPTROOT/startAll.py "$@"

--- a/startProc
+++ b/startProc
@@ -16,6 +16,9 @@ port=$2
 cfg=$3
 shift;shift;shift
 if test X$SCRIPTROOT == X; then export SCRIPTROOT=$PYPS_ROOT/config/$cfg/iocmanager; fi
+if [ ! -f "$SCRIPTROOT"/getDirectory.py ]; then
+    export SCRIPTROOT="$(dirname "$(realpath "${0}")")"
+fi
 
 # Start a new log if running procServ-2.6.0-SLAC.
 if test X$PROCSERVPID != X; then kill -HUP $PROCSERVPID; fi


### PR DESCRIPTION
There is an issue now where for txi and tst we can't launch rhel5 or rhel7 iocs because:

- the old startup scripts jump from wherever they launch from to the hutch-specific directory $PYPS_ROOT/config/$hutch/iocmanager
- the hutch-specific directories here now point to R3.0.0 for the front-end
- the old startup scripts assume a directory structure that isn't present in R3.0.0
- a lot of them would fail anyway because we've switched to conda

I think the cleanest way to move forward is to release a hotfix for the R2 series that falls back to using "current directory" when the hutch's directory has moved on for rocky9 support.