### PR TITLE
FIX: make sure the version combobox resets to match the dialog selection

### DIFF
--- a/iocmanager/table_delegate.py
+++ b/iocmanager/table_delegate.py
@@ -195,9 +195,14 @@ class IOCTableDelegate(QStyledItemDelegate):
                 # Clear the host from last time
                 self.hostdialog.ui.hostname.setText("")
             case TableColumn.VERSION:
-                # Reset to index 0 (the last one the user picked)
+                # Backup: reset to index 0 (the one in the config file)
                 # Often not needed except if resetting the widget later
                 editor.setCurrentIndex(0)
+                # Override with a set of the currentText as in HOST above
+                # This makes it so after we complete the dialog the value sticks
+                # Note: this is a no-op of there is no matching string,
+                # one must be added in setModelData
+                editor.setCurrentText(str(self.model.data(index)))
 
     def setModelData(
         self, editor: QWidget, model: QAbstractItemModel, index: QModelIndex


### PR DESCRIPTION
There is a bug right now where if there is more than (zero? one?) history element in the version combobox, the user can't pick a new version from the file select menu, due to an error in the implementation of the delegate.

This was already implemented correctly for the host combobox, delegate, but not for the version combobox delegate.

Basically, the way delegates work in a table model is that the editing of a field in the model is "delegated" to a widget (in this case, a combobox). When the combobox loses focus, the string contents of the combobox will be applied to the model via `setData`.

In this case, we're adding new hosts/versions on the fly that didn't exist in the combobox before. Therefore, the combobox must ultimately end up containing any string that we want to apply to the model. The new string is already added to the combobox elsewhere in the code, but the index of the combobox is never updated until this step. Without these calls, the index always either resets to zero or stays at "new version", prompting the user to use the path dialog again, both of which are bad. This is the natural place to update the index because this operation is useful any time we "reset" the combobox (which doesn't happen too often, to be frank).

I had some alternate solutions involving closing the delegate early but these all ended up having usability issues.