### PR TITLE
MNT: retry the startup of procmgrd

### DIFF
--- a/iocmanager/procserv_tools.py
+++ b/iocmanager/procserv_tools.py
@@ -561,7 +561,7 @@ def start_proc(cfg: str, ioc_proc: IOCProc, local: bool = False) -> None:
             "which sometimes is written erroneously to skip initIOC entirely. "
             "Other common issues include ioc.service not being enabled or installed, "
             "or something going wrong at host boot, "
-            f"such as {ctrlport} being used by some other process."
+            f"such as port {ctrlport} being used by some other process."
         ) from exc
     # telnet succeeded
     with tn:

--- a/iocmanager/procserv_tools.py
+++ b/iocmanager/procserv_tools.py
@@ -552,8 +552,16 @@ def start_proc(cfg: str, ioc_proc: IOCProc, local: bool = False) -> None:
         tn = open_telnet(host, ctrlport)
     except Exception as exc:
         raise RuntimeError(
-            f"Telnet to procmgr ({host}:{ctrlport}) failed. "
-            f"Please start the procServ process on host {host}."
+            f"Failed to start {ioc_proc.name}: "
+            f"telnet to procmgr ({host}:{ctrlport}) failed. "
+            "The procmgr processes are supposed to start during host boot via initIOC. "
+            "This can fail for a number of reasons. "
+            f"If {host} is online, the most typical issues involve "
+            f"the host config file at {env_paths.IOC_COMMON}/hosts/{host}/startup.cmd, "
+            "which sometimes is written erroneously to skip initIOC entirely. "
+            "Other common issues include ioc.service not being enabled or installed, "
+            "or something going wrong at host boot, "
+            f"such as {ctrlport} being used by some other process."
         ) from exc
     # telnet succeeded
     with tn:

--- a/scripts/initIOC
+++ b/scripts/initIOC
@@ -64,7 +64,19 @@ launchProcMgrD()
     ctrlport=$3
     logport=$(( ctrlport + 1 ))
     PROCMGRD_LOGFILE=$PROCMGRD_LOG_DIR/$2.log
-    su "${cfgduser}" -s /bin/sh -c "${PROCMGRD_BIN} ${PROCMGRD_ARGS} -l ${logport} --logfile ${PROCMGRD_LOGFILE} ${ctrlport} ${PROCMGRD_SHELL}"
+    for slp in 2 5 10 30 60 end; do
+        if su "${cfgduser}" -s /bin/sh -c "${PROCMGRD_BIN} ${PROCMGRD_ARGS} -l ${logport} --logfile ${PROCMGRD_LOGFILE} ${ctrlport} ${PROCMGRD_SHELL}"; then
+            echo "Successfully started $2"
+            break
+        elif [[ "${slp}" == "end" ]]; then
+            echo "Ran out of tries, skip $2"
+            # Exit early, fixTelnet will error out anyway with a traceback
+            return
+        else
+            echo "Failed to start $2, retry in $slp seconds"
+            sleep $slp
+        fi
+    done
     fixTelnet "${ctrlport}"
 }
 


### PR DESCRIPTION
See https://jira.slac.stanford.edu/browse/ECS-8484

In short, our rocky9 machines are having some startup shenanigans where temporarily these procServ processes are unable to start because the port is already in use:
```
Caught an exception creating the initial control telnet port: Bad file descriptor
<snip>/bin/procmgrd0: Exiting with error code: 98
```
So, I'm amending the startup script to retry these multiple times with timed back-offs.

In prod, this has only shown up on the txi ioc hosts and has been inconsistent. For example, it happened on the wave8 host twice (but not the third time) and on the cam host it happened for procmgr2 only (we start up procmgr0, 1, 2, it's a long story)

To test this, I went to the cam server where procmgr0 and procmgr1 were already running (but procmgr2 was not) and I ran `initIOC` manually. The idea of this test is that the error we've been getting at startup is indistinguishable from the error you'd get if you ran the script twice, so by running this a second time I should see timed back-off failures for procmgr0 and procmgr1 but a success for procmgr2, and that's exactly what happened:

```
<snip>/bin/procmgrd0: Exiting with error code: 98
Failed to start procmgrd0, retry in 2 seconds
Caught an exception creating the initial control telnet port: Bad file descriptor
<snip>/bin/procmgrd0: Exiting with error code: 98
Failed to start procmgrd0, retry in 5 seconds
Caught an exception creating the initial control telnet port: Bad file descriptor
<snip>/bin/procmgrd0: Exiting with error code: 98
Failed to start procmgrd0, retry in 10 seconds
Caught an exception creating the initial control telnet port: Bad file descriptor
<snip>/bin/procmgrd0: Exiting with error code: 98
Failed to start procmgrd0, retry in 30 seconds
Caught an exception creating the initial control telnet port: Bad file descriptor
<snip>/bin/procmgrd0: Exiting with error code: 98
Failed to start procmgrd0, retry in 60 seconds
Caught an exception creating the initial control telnet port: Bad file descriptor
<snip>/bin/procmgrd0: Exiting with error code: 98
Ran out of tries, skip procmgrd0
Caught an exception creating the initial control telnet port: Bad file descriptor
<snip>/bin/procmgrd1: Exiting with error code: 98
Failed to start procmgrd1, retry in 2 seconds
Caught an exception creating the initial control telnet port: Bad file descriptor
<snip>/bin/procmgrd1: Exiting with error code: 98
Failed to start procmgrd1, retry in 5 seconds
Caught an exception creating the initial control telnet port: Bad file descriptor
<snip>/bin/procmgrd1: Exiting with error code: 98
Failed to start procmgrd1, retry in 10 seconds
Caught an exception creating the initial control telnet port: Bad file descriptor
<snip>/bin/procmgrd1: Exiting with error code: 98
Failed to start procmgrd1, retry in 30 seconds
Caught an exception creating the initial control telnet port: Bad file descriptor
<snip>/bin/procmgrd1: Exiting with error code: 98
Failed to start procmgrd1, retry in 60 seconds
Caught an exception creating the initial control telnet port: Bad file descriptor
<snip>/bin/procmgrd1: Exiting with error code: 98
Ran out of tries, skip procmgrd1
<snip>/bin/procmgrd2: spawning daemon process: 1706200
Successfully started procmgrd2
```