### PR TITLE
ENH/FIX: various adjustments to commit_config.

### DIFF
--- a/iocmanager/config.py
+++ b/iocmanager/config.py
@@ -32,7 +32,7 @@ from .hioc_tools import get_hard_ioc_dir_for_display
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_COMMITHOST = "psbuild-rhel7"
+DEFAULT_COMMITHOST = "psbuild-rhel7-01"
 
 
 @dataclass(eq=True)

--- a/iocmanager/tests/interactive.py
+++ b/iocmanager/tests/interactive.py
@@ -21,6 +21,7 @@ from pytest import MonkeyPatch
 from qtpy.QtWidgets import QApplication, QDialog
 
 from ..cli import main as cli_main
+from ..commit import commit_config
 from ..config import Config, IOCProc, IOCStatusFile
 from ..dialog_add_ioc import AddIOCDialog
 from ..dialog_apply_verify import verify_dialog
@@ -147,6 +148,14 @@ def main() -> int:
                 case "xterm_terminal":
                     proc = run_in_xterm(title="Test run_in_xterm", args=args, out=None)
                     return proc.wait()
+                case "ssh_for_commit":
+                    return commit_config(
+                        hutch="commit_test",
+                        comment="test comment",
+                        show_output=True,
+                        ssh_verbose=1,
+                        script="echo",
+                    ).returncode
                 case other:
                     raise RuntimeError(f"Unhandled command {other}")
 

--- a/iocmanager/tests/pyps_root/config/commit_test/iocmanager.cfg
+++ b/iocmanager/tests/pyps_root/config/commit_test/iocmanager.cfg
@@ -1,0 +1,8 @@
+COMMITHOST = "psbuild-rhel7-01"
+allow_console = True
+
+hosts = [
+]
+
+procmgr_config = [
+]

--- a/iocmanager/tests/test_config.py
+++ b/iocmanager/tests/test_config.py
@@ -188,6 +188,7 @@ def test_find_iocs():
 def test_get_hutch_list():
     # See folders in pyps_root/config
     assert sorted(get_hutch_list()) == [
+        "commit_test",
         "pytest",
         "second_hutch",
     ]


### PR DESCRIPTION
This corresponds to the issues in https://jira.slac.stanford.edu/browse/ECS-8485

The most egregious issue was that, since the commit function needs to ssh, if it runs ssh and prompts for a password in the terminal, that password prompt takes focus and all gui elements freeze.

The changes I made are:
- Make `commit_config` fail immediately instead of freezing the gui to wait for user input by using the `BatchMode=yes` ssh option. This option is designed for scripting, and it causes the function to exit instead of asking for user input.
- Kill the stdin to the ssh process too, just to be paranoid. If the script that the ssh process calls asks for user input, this should also become an error that ends the commit.
- Make sure we can still apply config even if the commit fails. The user will now be prompted with an error message that explains that yes, the commit failed, but at least the write succeeded, which will then lead into the apply confirmation dialog.
- Add various ways to debug the `commit_config` interactively, these were helpful in tracking down what was wrong.
- Switch the default commit host to one that works

This last one is actually why my commits were failing- the commithost needs to be `psbuild-rhel7-01`, not `psbuild-rhel7`. Using the alias here causes some kerberos errors, but also every ioc manager needs to use the same commit host if they use the same config repo, so this is actually more correct. I've adjusted the tst config to use the correct commithost and I've changed the default here.
