### PR TITLE
ENH: improve commit UX

### DIFF
--- a/iocmanager/commit.py
+++ b/iocmanager/commit.py
@@ -94,6 +94,24 @@ def commit_config(
     )
 
 
+def check_commit_possible(hutch: str) -> bool:
+    """
+    Returns True if an ssh to the commithost is possible, False otherwise.
+
+    This can be called before we prompt a user to make a commit to save
+    them the trouble of figuring out their commit message.
+
+    It can also help us disambiguate issues relating to commiting: is the
+    ssh failing, or is the commit itself failing?
+    """
+    try:
+        # : is a built-in command that does nothing with exit status 0
+        commit_config(hutch=hutch, comment="", show_output=False, script=":")
+    except Exception:
+        return False
+    return True
+
+
 def get_commithost(hutch: str) -> str:
     """
     For a specific hutch, get the server we're supposed to commit on.

--- a/iocmanager/main_window.py
+++ b/iocmanager/main_window.py
@@ -284,7 +284,7 @@ class IOCMainWindow(QMainWindow):
                         f"{self.model.config.commithost} without a password.\n\n"
                         "This may require you to kinit and/or aklog for kerberos auth "
                         "or source ssh-agent-helper for key-based auth."
-                        "\n\nSave anyway?",
+                        "\n\nContinue anyway?",
                         QMessageBox.Yes | QMessageBox.Cancel,
                         QMessageBox.Yes,
                     )
@@ -296,7 +296,7 @@ class IOCMainWindow(QMainWindow):
                     QMessageBox.information(
                         self,
                         "Commits disabled for user",
-                        f"Commits are disabled for {self.user}.\n\nSave anyway?",
+                        f"Commits are disabled for {self.user}.\n\nContinue anyway?",
                         QMessageBox.Yes | QMessageBox.Cancel,
                         QMessageBox.Yes,
                     )


### PR DESCRIPTION
As a follow-up to #24, try to be more friendly to the user with the commit experience.

- Check if the user can successfully commit early in the GUI's lifetime
- Use this information to decide whether to prompt for commits or to warn that the user cannot commit.
- Restore missing feature: some user ssh can be disabled with the nossh file (accidentally forgot this in the R3 update)
- Revamp the warning messages to be more useful
- Revise the dialog to be agnostic between "save" and "apply" (because we might be in either)

Screenshots:
<img width="1602" height="557" alt="image" src="https://github.com/user-attachments/assets/cabb8fb1-272a-460e-938a-e08bae7cb5ba" />

<img width="1602" height="557" alt="image" src="https://github.com/user-attachments/assets/cd72baf5-ac3d-4006-9cb6-11bd660c420a" />

