### PR TITLE
FIX: versioning-related issues

### DIFF
--- a/COMPILE
+++ b/COMPILE
@@ -13,3 +13,6 @@ echo "(re-)build .py files from .ui"
 "${IOCMAN_PY_BIN}"/pyuic5 -o iocmanager/ui_find_pv.py ui/find_pv.ui
 "${IOCMAN_PY_BIN}"/pyuic5 -o iocmanager/ui_hostname.py ui/hostname.ui
 "${IOCMAN_PY_BIN}"/pyuic5 -o iocmanager/ui_ioc.py ui/ioc.ui
+
+echo "Update static version number"
+"${IOCMAN_PY_BIN}"/python -m setuptools_scm --force-write-version-files

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+all:
+	./COMPILE

--- a/iocmanager/main_window.py
+++ b/iocmanager/main_window.py
@@ -95,7 +95,7 @@ class IOCMainWindow(QMainWindow):
 
         # Set up all the qt objects we'll need
         # Helpful title: which hutch and iocmanager version we're using
-        self.setWindowTitle(f"{hutch.upper()} iocmanager {version_str}")
+        self.setWindowTitle(f"{hutch.upper()} iocmanager R{version_str}")
         # Re-usable dialogs
         self.commit_dialog = CommitDialog(hutch=hutch, parent=self)
         self.find_pv_dialog = FindPVDialog(

--- a/iocmanager/version.py
+++ b/iocmanager/version.py
@@ -27,6 +27,15 @@ class VersionProxy(UserString):
         self._version = None
 
     def _get_version(self) -> Optional[str]:
+        # Check this first because it's faster
+        # Might be out of date in dev checkouts but that's ok
+        try:
+            from ._version import version  # noqa: F401
+
+            return version
+        except ImportError:
+            ...
+
         # Checking for directory is faster than failing out of get_version
         repo_root = Path(__file__).resolve().parent.parent
         if (repo_root / ".git").exists() or (repo_root / ".git_archival.txt").exists():
@@ -37,15 +46,6 @@ class VersionProxy(UserString):
                 return get_version(root="..", relative_to=__file__)
             except (ImportError, LookupError):
                 ...
-
-        # Check this second because it can exist in a git repo if we've
-        # done a build at least once.
-        try:
-            from ._version import version  # noqa: F401
-
-            return version
-        except ImportError:
-            ...
 
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ file = "LICENSE.md"
 
 [tool.setuptools_scm]
 write_to = "iocmanager/_version.py"
+tag_regex = '^R(\d+\.\d+\.\d+)$'
 
 [tool.setuptools.packages.find]
 where = [ ".",]


### PR DESCRIPTION
Resolve small issues related to versioning/deployment. This is the last thing to merge before the R3.0.1 tag because it makes it easier to deploy tags.

1. Employ a custom regex for `setuptools_scm` so it know about the letter `R`. For the purposes of python packaging, `R3.0.0` will be parsed as `3.0.0`.
2. Rearrange the priorities in `version.py` for this application to use the `_version.py` file first. This is because I'm going to deploy these from git clones and I want to use the contents of the file for quick processing instead of whatever `git` says.
3. Make `_version.py` file also get built on `COMPILE`
4. Add dead simple `Makefile` so I can just type `make` to run `COMPILE` (could be made more sophisticated). This is largely here because when people see a `Makefile` they realize some make-ing has to be done, and I am one of these people, and it's really easy to forget to `./COMPILE` but it's easy to `ls`, see a `Makefile`, and think "Ah! I should make!"
5. Put the R back in for the window title

closes #20 
addresses https://jira.slac.stanford.edu/browse/ECS-8456
