### PR TITLE
ENH: floating terminal improvements

### DIFF
--- a/iocmanager/main_window.py
+++ b/iocmanager/main_window.py
@@ -492,9 +492,12 @@ class IOCMainWindow(QMainWindow):
         """
         if not self._check_selected():
             return
+        pos = self.ui.menuIOC_Control.pos()
         run_in_floating_terminal(
             title=f"{self.current_ioc} logfile",
             cmd=f"tail -1000lf {env_paths.LOGBASE % self.current_ioc}",
+            xpos=pos.x(),
+            ypos=pos.y(),
         )
 
     def action_show_console(self):
@@ -506,9 +509,12 @@ class IOCMainWindow(QMainWindow):
         if not self._check_selected():
             return
         ioc_proc = self.model.get_ioc_proc(ioc=self.current_ioc)
+        pos = self.ui.menuIOC_Control.pos()
         run_in_floating_terminal(
             title=f"{self.current_ioc} telnet session",
             cmd=f"telnet {ioc_proc.host} {ioc_proc.port}",
+            xpos=pos.x(),
+            ypos=pos.y(),
         )
 
     def action_help(self):

--- a/iocmanager/terminal.py
+++ b/iocmanager/terminal.py
@@ -26,7 +26,11 @@ logger = logging.getLogger(__name__)
 
 
 def run_in_floating_terminal(
-    title: str, cmd: str, out: int | None = subprocess.DEVNULL
+    title: str,
+    cmd: str,
+    out: int | None = subprocess.DEVNULL,
+    xpos: int = 0,
+    ypos: int = 0,
 ) -> subprocess.Popen:
     """
     Helper function for running a command in a compatible floating terminal.
@@ -55,7 +59,7 @@ def run_in_floating_terminal(
     """
     args = cmd.split(" ")
     if shutil.which("xterm") is not None:
-        return run_in_xterm(title, args, out)
+        return run_in_xterm(title, args, out, xpos, ypos)
     elif os.path.exists(env_paths.GNOME_TERMINAL_SERVER):
         return run_in_gnome_terminal(title, args, out)
     else:
@@ -99,7 +103,11 @@ def run_in_gnome_terminal(
 
 
 def run_in_xterm(
-    title: str, args: list[str], out: int | None = subprocess.DEVNULL
+    title: str,
+    args: list[str],
+    out: int | None = subprocess.DEVNULL,
+    xpos: int = 0,
+    ypos: int = 0,
 ) -> subprocess.Popen:
     """
     Subfunction of run_in_floating_terminal implemented for xterm.
@@ -117,7 +125,8 @@ def run_in_xterm(
         "-title",
         title,
         "-geometry",
-        "160x40",
+        f"160x40+{xpos}+{ypos}",
+        "-si",
         "-e",
     ]
     # A trick: if the process crashes, keep xterm open


### PR DESCRIPTION
- Create the floating terminal at the same position as the button that launches them
  - Originally: some default location that varied from system to system
- Apply the `-si` option so that the floating terminals don't jump to the bottom when new text comes in

addresses https://jira.slac.stanford.edu/browse/ECS-8537
addresses https://jira.slac.stanford.edu/browse/ECS-8454