### PR TITLE
FIX: rhel backcompat

### DIFF
--- a/iocmanager/procserv_tools.py
+++ b/iocmanager/procserv_tools.py
@@ -528,10 +528,7 @@ def start_proc(cfg: str, ioc_proc: IOCProc, local: bool = False) -> None:
     port = ioc_proc.port
     cmd = ioc_proc.cmd or "./st.cmd"
 
-    sr = os.getenv("SCRIPTROOT") or env_paths.STARTUP_DIR % cfg
-    if sr[-1] != "/":
-        sr += "/"
-    cmd = f"{sr}startProc {name} {port} {cfg} {cmd}"
+    cmd = f"startProc {name} {port} {cfg} {cmd}"
     log = env_paths.LOGBASE % name
     ctrlport = BASEPORT + 2 * (int(platform) - 1)
     logger.info(
@@ -542,7 +539,7 @@ def start_proc(cfg: str, ioc_proc: IOCProc, local: bool = False) -> None:
         platform,
     )
     cmd = (
-        f"{env_paths.PROCSERV_EXE} "
+        f"procServ "
         f"--logfile {log} "
         f"--name {name} "
         "--allow --coresize 0 --savelog "

--- a/scripts/default_env
+++ b/scripts/default_env
@@ -16,8 +16,11 @@ fi
 if [ -z "${PACKAGE_SITE_TOP}" ]; then
     export PACKAGE_SITE_TOP=/cds/group/pcds/package
 fi
+if [ -z "${EPICS_SITE_TOP}" ]; then
+    export EPICS_SITE_TOP=/cds/group/pcds/epics
+fi
 if [ -z "${IOC_ROOT}" ]; then
-    export IOC_ROOT="${PACKAGE_SITE_TOP}"/epics/ioc
+    export IOC_ROOT="${EPICS_SITE_TOP}"/ioc
 fi
 if [ -z "${CAMRECORD_ROOT}" ]; then
     export CAMRECORD_ROOT=/cds/group/pcds/controls/camrecord

--- a/scripts/initIOC
+++ b/scripts/initIOC
@@ -42,6 +42,9 @@ export PROCSERV_EXE
 PROCSERV_EXE="$(echo "${PROCSERV}" | cut -d ' ' -f 1)"
 PROCMGRD_DIR="$(dirname "${PROCSERV_EXE}")"
 
+# Make sure the procServ directory is on our path
+export PATH="${PROCMGRD_DIR}:${PATH}"
+
 # Make sure we have a procmgrd log directory
 if [ ! -d "${PROCMGRD_LOG_DIR}" ]; then
     su "${IOC_USER}" -s /bin/sh -c "mkdir -p ${PROCMGRD_LOG_DIR}"

--- a/scripts/startProc
+++ b/scripts/startProc
@@ -9,24 +9,23 @@ ioc=$1
 port=$2
 cfg=$3
 shift;shift;shift
-if test X"$SCRIPTROOT" == X; then export SCRIPTROOT=$PYPS_ROOT/config/$cfg/iocmanager; fi
 
 # Start a new log if running procServ-2.6.0-SLAC.
-if test X"$PROCSERVPID" != X; then kill -HUP "$PROCSERVPID"; fi
+if [ -n "$PROCSERVPID" ]; then
+	kill -HUP "$PROCSERVPID"
+fi
 
 # Setup the IOC user environment.
 export IOC="$ioc"
-# source "$IOC_COMMON"/All/"${cfg}"_env.sh
-source /cds/group/pcds/epics-dev/zlentz/iocCommon-All/"${cfg}_env.sh"
+source "$IOC_COMMON"/All/"${cfg}"_env.sh
 
 dir="$("$SCRIPTROOT"/getDirectory "$ioc" "$cfg")"
-if test "$dir" == NO_DIRECTORY; then
-    if test X"$PROCSERVPID" != X; then
-        kill -9 "$PROCSERVPID";
-	exit 0;
-    else
-        while test 1 == 1; do sleep 3600; done;
-    fi
+if [ "$dir" == "NO_DIRECTORY" ]; then
+	echo "No directory for ${ioc} in ${cfg}, exiting"
+    if [ -n "$PROCSERVPID" ]; then
+        kill -9 "$PROCSERVPID"
+	fi
+	exit 1
 fi
 cd "$IOC_ROOT"/..
 if test -d "$dir"; then cd "$dir"; fi

--- a/startProc
+++ b/startProc
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+# Backwards compatibility script
+# Delete me once everything is rocky9
+
+# If we got here, we might be rhel5 or we might be rhel7
+# Redirect scriptroot to the py2 version and launch from there
+export SCRIPTROOT=/cds/group/pcds/pyps/apps/iocmanager/latest
+$SCRIPTROOT/startProc "$@"


### PR DESCRIPTION
I tested this a bit on the tst network. I also verified that it freed ioc-cxi-spec-01 and spec-02 from their bootloops without any extra expert interventions (they managed to find the new top-level `startProc`)

See https://jira.slac.stanford.edu/browse/ECS-8594

1. In cases where we ask the server to start processes, etc., use the server's local startProc and procServ on the path instead of hardcoding our known latest versions. This makes our different versions more compatible with each other.
2. Fix bad IOC_ROOT environment variable that was only valid with a /cds root, not a /reg root
3. Restore old behavior to put procServ back on the path in service of point 1
4. Fix an issue where startProc was referring to a hard-coded dev area, also clean up this script slightly to remove an (intentional??) infinite loop
5. Add a top-level startProc for old servers that meander their way into here that redirects them to the newest old version of startProc. New setups target scripts/startProc instead.