### PR TITLE
ENH: extend survey_os to build a confluence status page

### DIFF
--- a/iocmanager/scripts/rocky9_table.html.j2
+++ b/iocmanager/scripts/rocky9_table.html.j2
@@ -1,0 +1,212 @@
+<p>This page contains live information about the current status of rocky9 releases and deployments at LCLS.</p>
+<p>The source of this page's information is the iocmanager config files and the layout of the deployed ioc files on the filesystem.</p>
+<p>This page will be updated daily. If there is no update, there was no change from the previous day.</p>
+<p>
+  <ac:structured-macro ac:macro-id="4ce6b49a-8124-4b82-97ed-7041971533ad" ac:name="toc" ac:schema-version="1"/>
+</p>
+<h1>Hutch Status</h1>
+<p>This table is a general dashboard overview of our progress in each area and overall.</p>
+<table class="wrapped">
+  <colgroup>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+  </colgroup>
+  <tbody>
+    <tr>
+      <th scope="row">Hutch</th>
+      <th scope="col">total ioc count</th>
+      <th scope="col">rocky9 ioc count</th>
+      <th scope="col">rhel7 ioc count</th>
+      <th scope="col">rhel5 ioc count</th>
+      <th scope="col">Other OS ioc count</th>
+      <th scope="col">Error checking OS ioc count</th>
+      <th scope="col">Common ioc ready count</th>
+      <th scope="col">Common ioc not ready count</th>
+      <th scope="col">No common ioc count</th>
+    </tr>
+{% for info in summary_objs %}
+    <tr>
+      <th scope="row">{{ info.hutch }}</th>
+      <td>{{ info.total_count }}</td>
+      <td>{{ info.rocky9_count }}</td>
+      <td>{{ info.rhel7_count }}</td>
+      <td>{{ info.rhel5_count }}</td>
+      <td>{{ info.other_count }}</td>
+      <td>{{ info.error_count }}</td>
+      <td>{{ info.common_ready_count }}</td>
+      <td>{{ info.common_not_ready_count }}</td>
+      <td>{{ info.no_common_count }}</td>
+    </tr>
+{% endfor %}
+  </tbody>
+</table>
+{% for info in hutch_dicts %}
+<h2>{{ info["hutch"] }}</h2>
+<p>This table is the current status of every IOC in {{ info["hutch"] }}. It can be used to understand which IOCs can be updated for {{ info["hutch"] }} and which common release to update them to.</p>
+<table class="wrapped">
+  <colgroup>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+  </colgroup>
+  <tbody>
+    <tr>
+      <th scope="col">IOC Name</th>
+      <th scope="col">Enabled</th>
+      <th scope="col">Current OS</th>
+      <th scope="col">Host</th>
+      <th scope="col">Common IOC Status</th>
+      <th scope="col">Common IOC Name</th>
+      <th scope="col">Using Common Release</th>
+      <th scope="col">Latest Common Release</th>
+    </tr>
+{% for ioc in info["iocs"] %}
+    <tr>
+      <td>{{ ioc.name }}</td>
+      <td>{{ ioc.enabled }}</td>
+      <td>{{ ioc.host_os }}</td>
+      <td>{{ ioc.hostname }}</td>
+      <td>{{ ioc.common_status }}</td>
+      <td>{{ ioc.common_name }}</td>
+      <td>{{ ioc.using_release }}</td>
+      <td>{{ ioc.latest_release }}</td>
+    </tr>
+{% endfor %}
+  </tbody>
+</table>
+{% endfor %}
+<h1>Host Status</h1>
+<p>This table is the per-host overview of ioc migration and possibility of migration. It can be used to identify hosts globally that are ready or nearly ready for an OS update.</p>
+<table class="wrapped">
+  <colgroup>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+  </colgroup>
+  <tbody>
+    <tr>
+      <th scope="col">Hostname</th>
+      <th scope="col">Hutch</th>
+      <th scope="col">Current OS</th>
+      <th scope="col">Total ioc count</th>
+      <th scope="col">Common ioc ready count</th>
+      <th scope="col">Common ioc not ready count</th>
+      <th scope="col">No common ioc count</th>
+    </tr>
+{% for info in host_objs %}
+    <tr>
+      <td>{{ info.hostname }}</td>
+      <td>{{ ", ".join(info.hutches) }}</td>
+      <td>{{ info.host_os }}</td>
+      <td>{{ info.total_count }}</td>
+      <td>{{ info.common_ready_count }}</td>
+      <td>{{ info.common_not_ready_count }}</td>
+      <td>{{ info.no_common_count }}</td>
+    </tr>
+{% endfor %}
+  </tbody>
+</table>
+{% for info in host_dicts %}
+<h2>{{ info["hostname"] }}</h2>
+<p>This table is the list of IOCs on {{ info["hostname"] }}. It can be used to plan work that would be needed to migrate this specific sever.</p>
+<table class="wrapped">
+  <colgroup class="">
+    <col class=""/>
+    <col class=""/>
+    <col class=""/>
+    <col class=""/>
+    <col class=""/>
+    <col class=""/>
+    <col class=""/>
+    <col class=""/>
+  </colgroup>
+  <tbody class="">
+    <tr class="">
+      <th>IOC Name</th>
+      <th>Enabled</th>
+      <th>Current OS</th>
+      <th>Hutch</th>
+      <th>Common IOC Status</th>
+      <th>Common IOC Name</th>
+      <th>Using Common Release</th>
+      <th>Latest Common Release</th>
+    </tr>
+{% for ioc in info["iocs"] %}
+    <tr class="">
+      <td>{{ ioc.name }}</td>
+      <td>{{ ioc.enabled }}</td>
+      <td>{{ ioc.host_os }}</td>
+      <td>{{ ioc.hutch }}</td>
+      <td>{{ ioc.common_status }}</td>
+      <td>{{ ioc.common_name }}</td>
+      <td>{{ ioc.using_release }}</td>
+      <td>{{ ioc.latest_release }}</td>
+    </tr>
+{% endfor %}
+  </tbody>
+</table>
+{% endfor %}
+<h1>Common IOC Status</h1>
+<p>This table is the per-common-ioc overview. It includes only common IOCs that are configured in iocmanager. It can be used to understand which common IOCs have been deployed with rocky9 support and which have not been. It can also be used to check which version to update your IOCs to.</p>
+<table class="wrapped">
+  <colgroup>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+    <col/>
+  </colgroup>
+  <tbody>
+    <tr>
+      <th scope="col">Common IOC Repo</th>
+      <th scope="col">Deploy Path</th>
+      <th scope="col">Supported OS</th>
+      <th scope="col">Number of IOCs Supported</th>
+      <th scope="col">Latest Deployed Version</th>
+    </tr>
+{% for info in common_ioc_objs %}
+    <tr>
+      <td>
+        <a href="https://github.com/pcdshub/{{ info.name }}">{{ info.name }}</a>
+      </td>
+      <td>{{ info.deploy_path }}</td>
+      <td>{{ info.supported_os }}</td>
+      <td>{{ info.total_deploy_count }}</td>
+      <td>{{ info.latest_version }}</td>
+    </tr>
+{% endfor %}
+  </tbody>
+</table>
+<h1>Big Paste</h1>
+<p>For people who like pure cli text</p>
+<ac:structured-macro ac:macro-id="17109988-8ac3-4e98-94e2-907374238786" ac:name="expand" ac:schema-version="1">
+  <ac:rich-text-body>
+    <ac:structured-macro ac:macro-id="df5f6888-2156-412c-b3a1-a12169b07d4e" ac:name="code" ac:schema-version="1">
+      <ac:parameter ac:name="language">text</ac:parameter>
+      <ac:plain-text-body><![CDATA[{{ plain_text_output }}]]></ac:plain-text-body>
+    </ac:structured-macro>
+    <p>
+      <br/>
+    </p>
+  </ac:rich-text-body>
+</ac:structured-macro>
+<p>
+  <br/>
+</p>

--- a/iocmanager/scripts/survey_os.py
+++ b/iocmanager/scripts/survey_os.py
@@ -788,11 +788,12 @@ def get_common_latest(common_ioc: str) -> str:
 
 
 def build_rocky9_table(hutches: list[str]) -> str:
-    stats_page = ConfluenceStatsPage.from_hutch_list(hutch_list=hutches)
+    confluence_hutches = [hutch for hutch in hutches if hutch != "all"]
+    stats_page = ConfluenceStatsPage.from_hutch_list(hutch_list=confluence_hutches)
     with open(Path(__file__).parent / "rocky9_table.html.j2", "r") as fd:
         template = jinja2.Template(fd.read())
     # Put things into the table orders
-    hutch_order = sorted(hutch for hutch in hutches if hutch != "all")
+    hutch_order = sorted(confluence_hutches)
     summary_objs = [stats_page.hutch_summary_table["all"]]
     hutch_dicts = []
     for hutch in hutch_order:
@@ -811,7 +812,11 @@ def build_rocky9_table(hutches: list[str]) -> str:
     common_ioc_objs = list(stats_page.common_ioc_summary_table.values())
     common_ioc_objs.sort(key=lambda obj: obj.total_deploy_count, reverse=True)
     # Run the old survey too for plain text output
-    results = SurveyResult.from_hutch_list(hutch_list=hutches)
+    if "all" in hutches:
+        survey_hutches = ["all"]
+    else:
+        survey_hutches = hutches
+    results = SurveyResult.from_hutch_list(hutch_list=survey_hutches)
     with contextlib.redirect_stdout(io.StringIO()) as fd:
         for hutch_res in results.hutch_results:
             stats = SurveyStats.from_results(hutch_res.ioc_results)

--- a/iocmanager/scripts/survey_os.py
+++ b/iocmanager/scripts/survey_os.py
@@ -750,7 +750,11 @@ class ConfluenceStatsPage:
 
 @functools.lru_cache(maxsize=1024)
 def get_common_status(common_ioc: str) -> CommonStatus:
-    if common_ioc == UNKNOWN or "/cds/group/pcds/epics/ioc/" not in common_ioc:
+    if (
+        common_ioc == UNKNOWN
+        or "/cds/group/pcds/epics/ioc/" not in common_ioc
+        or "/common/" not in common_ioc
+    ):
         return CommonStatus.NO_COMMON
     supp_os = get_supported_os(common_ioc=common_ioc)
     if supp_os == GOAL_OS:
@@ -810,6 +814,7 @@ def build_rocky9_table(hutches: list[str]) -> str:
         local_iocs = [stats_page.host_tables[host][ioc] for ioc in local_ioc_order]
         host_dicts.append({"hostname": host, "iocs": local_iocs})
     common_ioc_objs = list(stats_page.common_ioc_summary_table.values())
+    common_ioc_objs.sort(key=lambda obj: obj.name)
     common_ioc_objs.sort(key=lambda obj: obj.total_deploy_count, reverse=True)
     # Run the old survey too for plain text output
     if "all" in hutches:

--- a/iocmanager/scripts/survey_os.py
+++ b/iocmanager/scripts/survey_os.py
@@ -3,9 +3,12 @@ This script uses IOC manager to survey the state of operating system update effo
 """
 
 import argparse
+import contextlib
 import dataclasses
 import datetime
+import enum
 import functools
+import io
 import logging
 import os
 import re
@@ -14,6 +17,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Iterable
 
+import jinja2
 from packaging.version import InvalidVersion, Version
 
 from ..config import IOCProc, get_host_os, read_config
@@ -96,6 +100,14 @@ def get_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--confluence-table",
+        action="store_true",
+        help=(
+            "Ignore other arguments and create the confluence table html. "
+            "This always includes disabled IOCs."
+        ),
+    )
+    parser.add_argument(
         "--debug-ioc",
         default="",
         help=(
@@ -133,6 +145,7 @@ class IOCResult:
     enabled: bool
     hostname: str
     snowflake: bool
+    parent_ioc: str
 
     @classmethod
     def from_ioc_proc[T: IOCResult](cls: type[T], ioc_proc: IOCProc) -> T:
@@ -171,6 +184,7 @@ class IOCResult:
             enabled=not ioc_proc.disable,
             hostname=ioc_proc.host,
             snowflake=snowflake,
+            parent_ioc=ioc_proc.parent,
         )
 
 
@@ -535,6 +549,284 @@ def get_one_host_os(hostname: str) -> str:
         return UNKNOWN
 
 
+class CommonStatus(enum.StrEnum):
+    READY = "ready"
+    NOT_READY = "not ready"
+    NOT_MIGRATING = "not migrating"
+    NO_COMMON = "no common IOC"
+
+
+@dataclasses.dataclass
+class ConfluenceIOCInfo:
+    name: str
+    enabled: bool
+    host_os: str
+    hostname: str
+    hutch: str
+    common_status: CommonStatus
+    common_name: str
+    using_release: str
+    latest_release: str
+
+
+@dataclasses.dataclass
+class ConfluenceHutchSummaryRow:
+    hutch: str
+    total_count: int = 0
+    rocky9_count: int = 0
+    rhel7_count: int = 0
+    rhel5_count: int = 0
+    other_count: int = 0
+    error_count: int = 0
+    common_ready_count: int = 0
+    common_not_ready_count: int = 0
+    no_common_count: int = 0
+
+    def add_ioc(self, info: ConfluenceIOCInfo):
+        self.total_count += 1
+        if info.host_os == "rhel9":
+            self.rocky9_count += 1
+        elif info.host_os == "rhel7":
+            self.rhel7_count += 1
+        elif info.host_os == "rhel5":
+            self.rhel5_count += 1
+        elif info.host_os == UNKNOWN:
+            self.error_count += 1
+        else:
+            self.other_count += 1
+        match info.common_status:
+            case CommonStatus.READY:
+                self.common_ready_count += 1
+            case CommonStatus.NOT_READY:
+                self.common_not_ready_count += 1
+            case _:
+                self.no_common_count += 1
+
+
+@dataclasses.dataclass
+class ConfluenceHostSummaryRow:
+    hostname: str
+    host_os: str
+    hutches: list[str] = dataclasses.field(default_factory=list)
+    total_count: int = 0
+    common_ready_count: int = 0
+    common_not_ready_count: int = 0
+    no_common_count: int = 0
+
+    def add_ioc(self, info: ConfluenceIOCInfo):
+        if info.hutch not in self.hutches:
+            self.hutches.append(info.hutch)
+            self.hutches.sort()
+        self.total_count += 1
+        match info.common_status:
+            case CommonStatus.READY:
+                self.common_ready_count += 1
+            case CommonStatus.NOT_READY:
+                self.common_not_ready_count += 1
+            case _:
+                self.no_common_count += 1
+
+
+@dataclasses.dataclass
+class ConfluenceCommonIOCRow:
+    name: str
+    deploy_path: str
+    supported_os: str
+    latest_version: str
+    total_deploy_count: int = 0
+
+    @classmethod
+    def from_pathname[T: ConfluenceCommonIOCRow](cls: type[T], pathname: str) -> T:
+        # Real name starts at /ioc/
+        name = "ioc-" + pathname.split("/ioc/")[1].replace("/", "-")
+        deploy_path = pathname
+        supported_os = get_supported_os(pathname)
+        latest_version = get_common_latest(pathname)
+        total_deploy_count = 0
+        return cls(
+            name=name,
+            deploy_path=deploy_path,
+            supported_os=supported_os,
+            latest_version=latest_version,
+            total_deploy_count=total_deploy_count,
+        )
+
+
+@dataclasses.dataclass
+class ConfluenceStatsPage:
+    # Key by hutch
+    hutch_summary_table: dict[str, ConfluenceHutchSummaryRow]
+    # Key by host
+    host_summary_table: dict[str, ConfluenceHostSummaryRow]
+    # Key by hutch, then by ioc name
+    hutch_tables: dict[str, dict[str, ConfluenceIOCInfo]]
+    # Key by host, then by ioc name
+    host_tables: dict[str, dict[str, ConfluenceIOCInfo]]
+    # Key by deploy path
+    common_ioc_summary_table: dict[str, ConfluenceCommonIOCRow]
+
+    @classmethod
+    def from_hutch_list[T: ConfluenceStatsPage](
+        cls: type[T], hutch_list: list[str]
+    ) -> T:
+        hutch_results = []
+        for hutch in hutch_list:
+            if hutch == "all":
+                procs = []
+                for hutch_name in ALL_HUTCHES:
+                    if hutch_name == "all":
+                        continue
+                    cfg = read_config(hutch_name)
+                    procs.extend(cfg.procs.values())
+            else:
+                config = read_config(hutch)
+                procs = config.procs.values()
+            hutch_results.append(HutchResult.from_procs(hutch=hutch, procs=procs))
+        return cls.from_results(hutch_results)
+
+    @classmethod
+    def from_results[T: ConfluenceStatsPage](
+        cls: type[T], results: Iterable[HutchResult]
+    ) -> T:
+        stats_page = cls(
+            hutch_summary_table={"all": ConfluenceHutchSummaryRow(hutch="all")},
+            host_summary_table={},
+            hutch_tables={},
+            host_tables={},
+            common_ioc_summary_table={},
+        )
+        for res in results:
+            stats_page.add_hutch_result(res)
+        return stats_page
+
+    def add_hutch_result(self, hutch_result: HutchResult):
+        for ioc_result in hutch_result.ioc_results:
+            self.add_ioc_result(hutch_result.hutch, ioc_result)
+
+    def add_ioc_result(self, hutch: str, ioc_result: IOCResult):
+        common_status = get_common_status(ioc_result.common_ioc)
+        if common_status == CommonStatus.NO_COMMON:
+            common_name = "None"
+            using_release = "None"
+            latest_release = "None"
+        else:
+            common_name = ioc_result.common_ioc.removeprefix("/cds/group/pcds/epics/")
+            using_release = get_parent_version(ioc_result.parent_ioc)
+            latest_release = get_common_latest(ioc_result.common_ioc)
+        info = ConfluenceIOCInfo(
+            name=ioc_result.name,
+            enabled=ioc_result.enabled,
+            host_os=get_one_host_os(ioc_result.hostname),
+            hostname=ioc_result.hostname,
+            hutch=hutch,
+            common_status=common_status,
+            common_name=common_name,
+            using_release=using_release,
+            latest_release=latest_release,
+        )
+        self.hutch_summary_table["all"].add_ioc(info)
+        if hutch not in self.hutch_summary_table:
+            self.hutch_summary_table[hutch] = ConfluenceHutchSummaryRow(hutch=hutch)
+        self.hutch_summary_table[hutch].add_ioc(info)
+        if ioc_result.hostname not in self.host_summary_table:
+            self.host_summary_table[ioc_result.hostname] = ConfluenceHostSummaryRow(
+                ioc_result.hostname, get_one_host_os(ioc_result.hostname)
+            )
+        self.host_summary_table[ioc_result.hostname].add_ioc(info)
+        if hutch not in self.hutch_tables:
+            self.hutch_tables[hutch] = {}
+        self.hutch_tables[hutch][ioc_result.name] = info
+        if ioc_result.hostname not in self.host_tables:
+            self.host_tables[ioc_result.hostname] = {}
+        self.host_tables[ioc_result.hostname][ioc_result.name] = info
+
+        if common_status in (CommonStatus.READY, CommonStatus.NOT_READY):
+            if ioc_result.common_ioc not in self.common_ioc_summary_table:
+                self.common_ioc_summary_table[ioc_result.common_ioc] = (
+                    ConfluenceCommonIOCRow.from_pathname(pathname=ioc_result.common_ioc)
+                )
+            self.common_ioc_summary_table[ioc_result.common_ioc].total_deploy_count += 1
+
+
+@functools.lru_cache(maxsize=1024)
+def get_common_status(common_ioc: str) -> CommonStatus:
+    if common_ioc == UNKNOWN or "/cds/group/pcds/epics/ioc/" not in common_ioc:
+        return CommonStatus.NO_COMMON
+    supp_os = get_supported_os(common_ioc=common_ioc)
+    if supp_os == GOAL_OS:
+        return CommonStatus.READY
+    elif supp_os in NEEDS_UPGRADE:
+        return CommonStatus.NOT_READY
+    else:
+        return CommonStatus.NOT_MIGRATING
+
+
+@functools.lru_cache(maxsize=1024)
+def get_parent_version(parent_ioc: str) -> str:
+    version_str = Path(parent_ioc).name
+    try:
+        Version(version_str.removeprefix("R"))
+    except InvalidVersion:
+        return "dev"
+    return version_str
+
+
+@functools.lru_cache(maxsize=1024)
+def get_common_latest(common_ioc: str) -> str:
+    highest_ver_str = "R0.0.0"
+    highest_version = Version("0.0.0")
+    for ver_path in Path(common_ioc).glob("*"):
+        ver_str = ver_path.name
+        try:
+            this_version = Version(ver_str.removeprefix("R"))
+        except Exception:
+            continue
+        if this_version > highest_version:
+            highest_version = this_version
+            highest_ver_str = ver_str
+    return highest_ver_str
+
+
+def build_rocky9_table(hutches: list[str]) -> str:
+    stats_page = ConfluenceStatsPage.from_hutch_list(hutch_list=hutches)
+    with open(Path(__file__).parent / "rocky9_table.html.j2", "r") as fd:
+        template = jinja2.Template(fd.read())
+    # Put things into the table orders
+    hutch_order = sorted(hutch for hutch in hutches if hutch != "all")
+    summary_objs = [stats_page.hutch_summary_table["all"]]
+    hutch_dicts = []
+    for hutch in hutch_order:
+        summary_objs.append(stats_page.hutch_summary_table[hutch])
+        local_ioc_order = sorted(ioc for ioc in stats_page.hutch_tables[hutch])
+        local_iocs = [stats_page.hutch_tables[hutch][ioc] for ioc in local_ioc_order]
+        hutch_dicts.append({"hutch": hutch, "iocs": local_iocs})
+    host_order = sorted(host for host in stats_page.host_summary_table)
+    host_objs = []
+    host_dicts = []
+    for host in host_order:
+        host_objs.append(stats_page.host_summary_table[host])
+        local_ioc_order = sorted(ioc for ioc in stats_page.host_tables[host])
+        local_iocs = [stats_page.host_tables[host][ioc] for ioc in local_ioc_order]
+        host_dicts.append({"hostname": host, "iocs": local_iocs})
+    common_ioc_objs = list(stats_page.common_ioc_summary_table.values())
+    common_ioc_objs.sort(key=lambda obj: obj.total_deploy_count, reverse=True)
+    # Run the old survey too for plain text output
+    results = SurveyResult.from_hutch_list(hutch_list=hutches)
+    with contextlib.redirect_stdout(io.StringIO()) as fd:
+        for hutch_res in results.hutch_results:
+            stats = SurveyStats.from_results(hutch_res.ioc_results)
+            stats.print_data()
+    plain_text_output = fd.getvalue()
+    return template.render(
+        summary_objs=summary_objs,
+        hutch_dicts=hutch_dicts,
+        host_objs=host_objs,
+        host_dicts=host_dicts,
+        common_ioc_objs=common_ioc_objs,
+        plain_text_output=plain_text_output,
+    )
+
+
 def main(sys_argv: list[str] | None = None) -> int:
     parser = get_parser()
     args = parser.parse_args(sys_argv)
@@ -543,6 +835,9 @@ def main(sys_argv: list[str] | None = None) -> int:
         hutches = ALL_HUTCHES
     else:
         hutches = [args.hutch]
+    if args.confluence_table:
+        print(build_rocky9_table(hutches))
+        return 0
     if args.debug_ioc:
         config = read_config(args.hutch)
         ioc_proc = config.procs[args.debug_ioc]


### PR DESCRIPTION
See https://jira.slac.stanford.edu/browse/ECS-8556
See https://confluence.slac.stanford.edu/spaces/PCDS/pages/623424952/Rocky9+EPICS+IOC+Migration+Live+Info

The code is a bit messy, maybe I should give it a few passes through

Basically: I'm going to put this through a cron that updates the linked confluence page often with status information about the rocky9 migration status.

I think jinja2 is a really great tool for this sort of thing

Known issues:

- [x] the hutch column in the host tables is incorrect
- [x] there is some double-counting of IOCs to track down (particularly in the host tables and the all ioc counts)
- [x] there are some non-common IOCs in the common IOCs table